### PR TITLE
removed cancel option from warranty request dropdown

### DIFF
--- a/includes/class-warranty-item.php
+++ b/includes/class-warranty-item.php
@@ -60,13 +60,16 @@ class WCRW_Warranty_Item {
         if ( 'addon_warranty' === $warranty['type'] ) {
             $this->type = 'addon_warranty';
 
-            $selected_warranty = $warranty['addon_settings'][$selected];
+            $selected_warranty = ! empty( $warranty['addon_settings'][$selected] ) ?
+            $warranty['addon_settings'][$selected] : '';
 
+            if ( ! empty( $selected_warranty ) ) {
             $this->data = [
                 'length' => 'limited',
                 'value'  => $selected_warranty['length'],
                 'duration' => $selected_warranty['duration'],
             ];
+            }
             return;
         }
     }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1015,6 +1015,7 @@ function wcrw_get_warranty_request_form_fields() {
         if ( in_array( $key, $settings_types ) ) {
             $allowed_types[$key] = $value;
         }
+        unset($allowed_types['cancel']);
     }
 
     $mandatory_fileds = [


### PR DESCRIPTION
There was this problem that customers could cancel order even after an order is completed. This edit fixes it